### PR TITLE
Fix: allow debug statement to log falsy values

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -43,7 +43,7 @@ function getStatsdApi ({ hostname, port, lynxOptions, transmit, prefix }) {
         client ? client.constructor.name : 'undefined',
         key, metric,
         method,
-        value ? `value=${value}` : '')
+        typeof value === 'undefined' ? '' : `value=${value}`)
       client[method](`${key}.${metric}`, value)
     }
   }

--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
     "eslint": "eslint lib tests",
     "mocha": "mocha --check-leaks tests/unit/*.js tests/unit/**/*.js",
     "nyc": "nyc --reporter=text --reporter=text-summary --reporter=html --report-dir=docs/reports/coverage npm run mocha",
-    "postnyc": "nyc check-coverage --statements 100 --branches 96 --functions 100 --lines 100"
+    "postnyc": "nyc check-coverage --statements 100 --branches 100 --functions 100 --lines 100"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above. -->

## Description
* If values such as `0` were sent, the value was not displayed in the debug statement.
* Tests have also been added to verify the calls to `debug()`

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
